### PR TITLE
flow revision resulting in twice the speed

### DIFF
--- a/lib/AutoSeed.rb
+++ b/lib/AutoSeed.rb
@@ -1,28 +1,23 @@
  require "AutoSeed/railtie" if defined?(Rails)
 
-  class AutoSeed
-    def self.generate (params = {})
-      Rails.application.eager_load!
+class AutoSeed
+  def self.generate (params = {})
+    Rails.application.eager_load!                   # Ensures models loaded
+    reject_attribs = ["id", "created_at", "updated_at"]  # Attributes to filter
+    insert_string = "Blah1234"                      # default string in attributes
 
-      # Filter the list of models from Active Record
-      models = ActiveRecord::Base.descendants.map { |model| model.name }
+    # Filter the list of models from Active Record based on options in params
+    models = ActiveRecord::Base.descendants.map { |model| model.name }
+    models = models & params['INCLUDE'].split(',') if params['INCLUDE']
+    models = models | params['REJECT'].split(',') if params['REJECT']
 
-      models = models & params['INCLUDE'].split(',') if params['INCLUDE']
-      models = models | params['REJECT'].split(',') if params['REJECT']
-
-      models.each do | model_name |
-
-      # Print the model creation method
-        puts "[{" + model_name.classify.constantize.all.map { |model|
-          model.attributes.reject{ |key| key == "id" }.map { |key, attribute|
-            key == "id" ? nil : "#{key}: '#{attribute}'"
-          }.join(", ")
-        }.join("},\n{")
-        + "}].each { |attributes| \n"
-        + model_name + ".find_or_create_by(attributes) }"
-
-      end
-
+    models.each do | model_name |
+      model = model_name.classify.constantize             # setup model to call
+      attribs = model.column_names - reject_attribs       # drop extra db columns 
+      attribs = attribs.map {|x| [x, insert_string]}.to_h # setup hash of columns
+      result = model.find_or_create_by!(attribs)          # save error msgs 
+      puts result                                         # output results
     end
   end
+end
 


### PR DESCRIPTION
Wanted to separate the presentation of result reporting from the process of seeding the database a bit more for molecularity and readability.

Side effect:  code is optimized a bit more for ordering rails likes & is 30-50% faster on 20 table (5 columns) db.
```
AutoSeed ran first
0.20960171800106764
0.017132912995293736
0.019087555119767785
0.016556123970076442
0.01671296381391585

AutoSeed2 ran first
0.20935685303993523
0.013123347889631987
0.008902532979846
0.009665229823440313
0.009277479955926538
```